### PR TITLE
Assign values for override-multiple and copy-params

### DIFF
--- a/draft-ietf-suit-update-management.cddl
+++ b/draft-ietf-suit-update-management.cddl
@@ -94,6 +94,8 @@ suit-condition-update-authorized        = 27
 suit-condition-version                  = 28
 
 suit-directive-wait                     = 29
+suit-directive-override-multiple        = 34
+suit-directive-copy-params              = 35
 
 suit-wait-event-authorization        = 1
 suit-wait-event-power                = 2

--- a/draft-ietf-suit-update-management.md
+++ b/draft-ietf-suit-update-management.md
@@ -289,6 +289,8 @@ Label | Name | Reference
 27 | Update Authorized | {{suit-condition-update-authorized}}
 28 | Version | {{suit-condition-version}}
 29 | Wait For Event | {{suit-directive-wait}}
+34 | Override Multiple | {{suit-directive-override-multiple}}
+35 | Copy Params | {{suit-directive-copy-params}}
 
 ## SUIT Parameters
 


### PR DESCRIPTION
These labels are not defined in the CDDL, and cause CDDL validation errors.