### PR TITLE
Use concise-swid-tag instead of concise-software-identifier

### DIFF
--- a/draft-ietf-suit-update-management.cddl
+++ b/draft-ietf-suit-update-management.cddl
@@ -1,5 +1,5 @@
 $$SUIT_severable-members-extensions //= (
-    suit-coswid => bstr .cbor concise-software-identity)
+    suit-coswid => bstr .cbor concise-swid-tag)
 
 $$severable-manifest-members-choice-extensions //= (
     suit-coswid => bstr .cbor SUIT_Command_Sequence / SUIT_Digest


### PR DESCRIPTION
The name of map was changed in [draft-ietf-sacm-coswid-09](https://author-tools.ietf.org/iddiff?url1=draft-ietf-sacm-coswid-08&url2=draft-ietf-sacm-coswid-09&difftype=--hwdiff).