### PR TITLE
Fix the type of suit-parameter-update-priority

### DIFF
--- a/draft-ietf-suit-update-management.cddl
+++ b/draft-ietf-suit-update-management.cddl
@@ -52,7 +52,7 @@ SUIT_Wait_Event_Argument_Other_Device_Version = [
 
 SUIT_Parameters //= (suit-parameter-use-before => uint)
 SUIT_Parameters //= (suit-parameter-minimum-battery => uint)
-SUIT_Parameters //= (suit-parameter-update-priority => uint)
+SUIT_Parameters //= (suit-parameter-update-priority => int)
 SUIT_Parameters //= (suit-parameter-version =>
     SUIT_Parameter_Version_Match)
 SUIT_Parameters //= (suit-parameter-wait-info =>


### PR DESCRIPTION
The draft text says,
> Applications MAY define their own meanings for the update priority. For example, critical reliability & vulnerability fixes MAY be given negative numbers

so that the argument type of suit-parameter-update-priority must be `int` .

I'm not sure but it might be better that the argument type of `suit-wait-event-power` is `uint` like `suit-parameter-minimum-battery` . It's not included in this PR.